### PR TITLE
Mongodb 2.1+ aggregate function

### DIFF
--- a/harstorage/controllers/results.py
+++ b/harstorage/controllers/results.py
@@ -70,7 +70,6 @@ class ResultsController(BaseController):
             c.metrics_table[4].append(result["requests"])
             c.metrics_table[5].append(round(result["full_load_time"]/1000.0, 1))
 
-        print c.metrics_table
         return render("/home/core.html")
 
     @restrict("GET")

--- a/harstorage/lib/MongoHandler.py
+++ b/harstorage/lib/MongoHandler.py
@@ -19,7 +19,8 @@ class MongoDB():
             database = config["app_conf"]["mongo_db"]
 
             # Collection
-            self.collection = pymongo.Connection(uri, safe=True)[database][collection]
+            #self.collection = pymongo.Connection(uri, safe=True)[database][collection]
+            self.collection = pymongo.mongo_client.MongoClient(host=uri, port=int(config["app_conf"]["mongo_port"]))[database][collection]
 
             # Indecies
             self.ensure_index()
@@ -40,7 +41,8 @@ class MongoDB():
             pswd = config["app_conf"]["mongo_pswd"]
             uri += user + ":" + pswd + "@"
 
-        return uri + host + ":" + port
+        #return uri + host + ":" + port
+        return uri + host
 
     def ensure_index(self):
         self.collection.ensure_index([("label", 1), ("timestamp", -1)])


### PR DESCRIPTION
Turned "group" mongodb statment into "aggregate" that is dramatically faster, but mongodb 2.1+ must be used.
